### PR TITLE
Add new config option to not deny on no MX record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### [1.2.0] - 2026-04-30
 
-- added new config option to not deny on missing or invalid MX record
+- changed [reject]no_mx to allow invalid MX record
 
 ### [1.1.0] - 2025-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [1.2.0] - 2026-04-30
+
+- added new config option to not deny on missing or invalid MX record
+
 ### [1.1.0] - 2025-06-15
 
 - config: remove attempted (but dysfunctional) reject_no_mx code, fixes #5

--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ This plugin uses the INI-style file format and accepts the following options:
   Allow MX records that return IP addresses instead of hostnames.
   This is not allowed as per the RFC, but some MTAs allow it.
 
-- [reject]no_mx=[true|false]
+- [reject]no_mx=[deny|defer|no]
 
-  Return DENY and reject the command if no MX record is found. Otherwise a
-  DENYSOFT (TEMPFAIL) is returned and the client will retry later.
+  "deny" returns DENY and rejects the command if no MX record is found. "defer"
+  returns a DENYSOFT (TEMPFAIL) and the client will retry later. "no" allows the
+  transaction to continue to the next plugin.
 
-  DNS errors always return DENYSOFT, so this should be safe to enable.
+  DNS errors always return DENYSOFT, so this should be safe to change to "deny".
+
+  This used to be a boolean, so to allow old config to work, true maps to deny
+  and false maps to defer.
 
 <!-- leave these buried at the bottom of the document -->
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ This plugin uses the INI-style file format and accepts the following options:
   returns a DENYSOFT (TEMPFAIL) and the client will retry later. "no" allows the
   transaction to continue to the next plugin.
 
-  DNS errors always return DENYSOFT, so this should be safe to change to "deny".
-
-  This used to be a boolean, so to allow old config to work, true maps to deny
-  and false maps to defer.
-
 <!-- leave these buried at the bottom of the document -->
 
 [ci-img]: https://github.com/haraka/haraka-plugin-mail_from.is_resolvable/actions/workflows/ci.yml/badge.svg

--- a/config/mail_from.is_resolvable.ini
+++ b/config/mail_from.is_resolvable.ini
@@ -3,4 +3,4 @@ allow_mx_ip=false
 re_bogus_ip=^(?:0\.0\.0\.0|255\.255\.255\.255|127\.)
 
 [reject]
-no_mx=true
+no_mx=deny

--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ exports.load_ini = function () {
     this.cfg.main.re_bogus_ip ||
       '^(?:0\\.0\\.0\\.0|255\\.255\\.255\\.255|127\\.)',
   )
+
+  const modes = { no: 'no', false: 'defer', defer: 'defer' }
+  this.reject_no_mx = modes[this.cfg.reject.no_mx] || 'deny'
 }
 
 exports.hook_mail = async function (next, connection, params) {
@@ -36,22 +39,6 @@ exports.hook_mail = async function (next, connection, params) {
   }
 
   const domain = mail_from.host
-
-  let rejectMode
-  switch (this.cfg.reject.no_mx) {
-    case 'no':
-      rejectMode = 'no'
-      break
-    case 'false':
-    case 'defer':
-      rejectMode = 'defer'
-      break
-    case 'true':
-    case 'deny':
-    default:
-      rejectMode = 'deny'
-      break
-  }
 
   connection.logdebug(this, `resolving MX for domain ${domain}`)
 
@@ -67,10 +54,10 @@ exports.hook_mail = async function (next, connection, params) {
 
   if (!exchanges || !exchanges.length) {
     results.add(this, { fail: 'has_fwd_dns', emit: true })
-    if (rejectMode === 'no') return next()
+    if (this.reject_no_mx === 'no') return next()
     else
       return next(
-        rejectMode === 'deny' ? DENY : DENYSOFT,
+        this.reject_no_mx === 'deny' ? DENY : DENYSOFT,
         'No MX for your FROM address',
       )
   }
@@ -114,10 +101,10 @@ exports.hook_mail = async function (next, connection, params) {
   }
 
   results.add(this, { fail: 'has_fwd_dns', emit: true })
-  if (rejectMode === 'no') return next()
+  if (this.reject_no_mx === 'no') return next()
   else
     return next(
-      rejectMode === 'deny' ? DENY : DENYSOFT,
+      this.reject_no_mx === 'deny' ? DENY : DENYSOFT,
       'No valid MX for your FROM address',
     )
 }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ exports.load_ini = function () {
   this.cfg = this.config.get(
     'mail_from.is_resolvable.ini',
     {
-      booleans: ['-main.allow_mx_ip', '+reject.no_mx'],
+      booleans: ['-main.allow_mx_ip'],
     },
     () => {
       this.load_ini()
@@ -37,6 +37,22 @@ exports.hook_mail = async function (next, connection, params) {
 
   const domain = mail_from.host
 
+  let rejectMode
+  switch (this.cfg.reject.no_mx) {
+    case 'no':
+      rejectMode = 'no'
+      break
+    case 'false':
+    case 'defer':
+      rejectMode = 'defer'
+      break
+    case 'true':
+    case 'deny':
+    default:
+      rejectMode = 'deny'
+      break
+  }
+
   connection.logdebug(this, `resolving MX for domain ${domain}`)
 
   let exchanges
@@ -51,10 +67,12 @@ exports.hook_mail = async function (next, connection, params) {
 
   if (!exchanges || !exchanges.length) {
     results.add(this, { fail: 'has_fwd_dns', emit: true })
-    return next(
-      this.cfg.reject.no_mx ? DENY : DENYSOFT,
-      'No MX for your FROM address',
-    )
+    if (rejectMode === 'no') return next()
+    else
+      return next(
+        rejectMode === 'deny' ? DENY : DENYSOFT,
+        'No MX for your FROM address',
+      )
   }
 
   if (this.cfg.main.allow_mx_ip) {
@@ -96,8 +114,10 @@ exports.hook_mail = async function (next, connection, params) {
   }
 
   results.add(this, { fail: 'has_fwd_dns', emit: true })
-  return next(
-    this.cfg.reject.no_mx ? DENY : DENYSOFT,
-    'No valid MX for your FROM address',
-  )
+  if (rejectMode === 'no') return next()
+  else
+    return next(
+      rejectMode === 'deny' ? DENY : DENYSOFT,
+      'No valid MX for your FROM address',
+    )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-mail_from.is_resolvable",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Haraka plugin that checks that the domain used in MAIL FROM is resolvable to an MX record",
   "main": "index.js",
   "files": [

--- a/test/index.js
+++ b/test/index.js
@@ -12,38 +12,18 @@ const { Resolver } = dnsPromises
 describe('mail_from.is_resolvable', function () {
   beforeEach(function () {
     this.plugin = new fixtures.plugin('mail_from.is_resolvable')
+    this.plugin.register()
 
-    this.configfile = {
-      main: {
-        allow_mx_ip: false,
-        re_bogus_ip: '^(?:0\\.0\\.0\\.0|255\\.255\\.255\\.255|127\\.)',
-      },
+    this.connection = fixtures.connection.createConnection()
+    this.connection.init_transaction()
 
-      reject: {
-        no_mx: 'deny',
-      },
-    }
+    this.txt = this.connection.transaction
 
-    if (this.plugin) {
-      this.plugin.config.get = function () {
-        return this.configfile
-      }.bind(this)
-    }
+    this.get_mx_spy = sinon.stub(net_utils, 'get_mx')
 
-    this.setup = () => {
-      this.plugin.register()
+    this.next = sinon.stub()
 
-      this.connection = fixtures.connection.createConnection()
-      this.connection.init_transaction()
-
-      this.txt = this.connection.transaction
-
-      this.get_mx_spy = sinon.stub(net_utils, 'get_mx')
-
-      this.next = sinon.stub()
-
-      this.domain = 'example.com'
-    }
+    this.domain = 'example.com'
   })
 
   afterEach(function () {
@@ -52,8 +32,6 @@ describe('mail_from.is_resolvable', function () {
 
   describe('hook_mail', function () {
     it('Allow - mail_from without host', async function () {
-      this.setup()
-
       await this.plugin.hook_mail(this.next, this.connection, [{}])
 
       assert.equal(this.txt.results.get(this.plugin).skip[0], 'null host')
@@ -63,8 +41,6 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - get_mx timeout', async function () {
-      this.setup()
-
       // Configure the stub to simulate a timeout
       const timeoutError = new Error('DNS request timed out')
       timeoutError.code = dnsPromises.TIMEOUT
@@ -87,8 +63,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - resolveMx timeout', async function () {
-      this.configfile.reject.no_mx = 'false'
-      this.setup()
+      this.plugin.reject_no_mx = 'deny'
 
       this.get_mx_spy.restore()
 
@@ -114,8 +89,6 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - No MX for your FROM address', async function () {
-      this.setup()
-
       this.get_mx_spy.resolves([])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -129,10 +102,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - No MX for your FROM address', async function () {
-      // Make sure old config works as intended.
-      this.configfile.reject.no_mx = 'false'
-      this.setup()
-
+      this.plugin.reject_no_mx = 'defer'
       this.get_mx_spy.resolves([])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -150,10 +120,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - No MX for your FROM address', async function () {
-      // Make sure old config works as intended.
-      this.configfile.reject.no_mx = 'true'
-      this.setup()
-
+      this.plugin.reject_no_mx = 'deny'
       this.get_mx_spy.resolves([])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -167,10 +134,9 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('Allow - MX is IP address', async function () {
-      this.configfile.main.allow_mx_ip = true
-      this.setup()
-
       this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
+
+      this.plugin.cfg.main.allow_mx_ip = true
 
       await this.plugin.hook_mail(this.next, this.connection, [
         new Address(`<test@${this.domain}>`),
@@ -183,8 +149,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - resolve4 and resolve6 both timeout', async function () {
-      this.configfile.reject.no_mx = 'deny'
-      this.setup()
+      this.plugin.reject_no_mx = 'deny'
 
       this.get_mx_spy.resolves([{ exchange: `mx.${this.domain}` }])
 
@@ -215,8 +180,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - DNS server failure', async function () {
-      this.configfile.reject.no_mx = 'deny'
-      this.setup()
+      this.plugin.reject_no_mx = 'deny'
 
       this.get_mx_spy.resolves([{ exchange: `mx.${this.domain}` }])
 
@@ -244,9 +208,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - No valid MX for the FROM address', async function () {
-      this.configfile.reject.no_mx = 'defer'
-      this.setup()
-
+      this.plugin.reject_no_mx = 'defer'
       this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -264,9 +226,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('Allow - No valid MX for the FROM address', async function () {
-      this.configfile.reject.no_mx = 'no'
-      this.setup()
-
+      this.plugin.reject_no_mx = 'no'
       this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -280,8 +240,6 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - No valid MX for the FROM address', async function () {
-      this.setup()
-
       this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -299,8 +257,6 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('Allow - valid MX hostname resolved to IPv6', async function () {
-      this.setup()
-
       this.resolve_mx_hosts_spy = sinon.stub(net_utils, 'resolve_mx_hosts')
 
       this.get_mx_spy.resolves([{ exchange: 'gmail-smtp-in.l.google.com' }])
@@ -319,8 +275,6 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('Allow - valid MX hostname resolved to IPv4', async function () {
-      this.setup()
-
       this.resolve_mx_hosts_spy = sinon.stub(net_utils, 'resolve_mx_hosts')
 
       this.get_mx_spy.resolves([{ exchange: 'gmail-smtp-in.l.google.com' }])
@@ -340,8 +294,6 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - MX hostname does not resolve', async function () {
-      this.setup()
-
       this.resolve_mx_hosts_spy = sinon.stub(net_utils, 'resolve_mx_hosts')
 
       this.get_mx_spy.resolves([{ exchange: 'mx.${this.domain}' }])

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - resolveMx timeout', async function () {
-      this.plugin.cfg.reject.no_mx = true
+      this.plugin.cfg.reject.no_mx = 'deny'
 
       this.get_mx_spy.restore()
 
@@ -102,7 +102,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - No MX for your FROM address', async function () {
-      this.plugin.cfg.reject.no_mx = false
+      // Make sure old config works as intended.
+      this.plugin.cfg.reject.no_mx = 'false'
       this.get_mx_spy.resolves([])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -117,6 +118,21 @@ describe('mail_from.is_resolvable', function () {
         DENYSOFT,
         'No MX for your FROM address',
       )
+    })
+
+    it('DENY - No MX for your FROM address', async function () {
+      // Make sure old config works as intended.
+      this.plugin.cfg.reject.no_mx = 'true'
+      this.get_mx_spy.resolves([])
+
+      await this.plugin.hook_mail(this.next, this.connection, [
+        new Address(`<test@${this.domain}>`),
+      ])
+
+      assert.ok(this.txt.results.has(this.plugin, 'fail', 'has_fwd_dns'))
+      sinon.assert.calledOnceWithExactly(this.get_mx_spy, this.domain)
+      sinon.assert.calledOnce(this.next)
+      sinon.assert.calledWith(this.next, DENY, 'No MX for your FROM address')
     })
 
     it('Allow - MX is IP address', async function () {
@@ -135,7 +151,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - resolve4 and resolve6 both timeout', async function () {
-      this.plugin.cfg.reject.no_mx = true
+      this.plugin.cfg.reject.no_mx = 'deny'
 
       this.get_mx_spy.resolves([{ exchange: `mx.${this.domain}` }])
 
@@ -166,7 +182,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - DNS server failure', async function () {
-      this.plugin.cfg.reject.no_mx = true
+      this.plugin.cfg.reject.no_mx = 'deny'
 
       this.get_mx_spy.resolves([{ exchange: `mx.${this.domain}` }])
 
@@ -194,7 +210,7 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - No valid MX for the FROM address', async function () {
-      this.plugin.cfg.reject.no_mx = false
+      this.plugin.cfg.reject.no_mx = 'defer'
       this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -209,6 +225,20 @@ describe('mail_from.is_resolvable', function () {
         DENYSOFT,
         'No valid MX for your FROM address',
       )
+    })
+
+    it('Allow - No valid MX for the FROM address', async function () {
+      this.plugin.cfg.reject.no_mx = 'no'
+      this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
+
+      await this.plugin.hook_mail(this.next, this.connection, [
+        new Address(`<test@${this.domain}>`),
+      ])
+
+      assert.ok(this.txt.results.has(this.plugin, 'fail', 'has_fwd_dns'))
+      sinon.assert.calledOnceWithExactly(this.get_mx_spy, this.domain)
+      sinon.assert.calledOnce(this.next)
+      assert.equal(this.next.getCall(0).args.length, 0)
     })
 
     it('DENY - No valid MX for the FROM address', async function () {

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ describe('mail_from.is_resolvable', function () {
     this.configfile = {
       main: {
         allow_mx_ip: false,
-        re_bogus_ip: '^(?:0\.0\.0\.0|255\.255\.255\.255|127\.)',
+        re_bogus_ip: '^(?:0\\.0\\.0\\.0|255\\.255\\.255\\.255|127\\.)',
       },
 
       reject: {

--- a/test/index.js
+++ b/test/index.js
@@ -12,18 +12,38 @@ const { Resolver } = dnsPromises
 describe('mail_from.is_resolvable', function () {
   beforeEach(function () {
     this.plugin = new fixtures.plugin('mail_from.is_resolvable')
-    this.plugin.register()
 
-    this.connection = fixtures.connection.createConnection()
-    this.connection.init_transaction()
+    this.configfile = {
+      main: {
+        allow_mx_ip: false,
+        re_bogus_ip: '^(?:0\.0\.0\.0|255\.255\.255\.255|127\.)',
+      },
 
-    this.txt = this.connection.transaction
+      reject: {
+        no_mx: 'deny',
+      },
+    }
 
-    this.get_mx_spy = sinon.stub(net_utils, 'get_mx')
+    if (this.plugin) {
+      this.plugin.config.get = function () {
+        return this.configfile
+      }.bind(this)
+    }
 
-    this.next = sinon.stub()
+    this.setup = () => {
+      this.plugin.register()
 
-    this.domain = 'example.com'
+      this.connection = fixtures.connection.createConnection()
+      this.connection.init_transaction()
+
+      this.txt = this.connection.transaction
+
+      this.get_mx_spy = sinon.stub(net_utils, 'get_mx')
+
+      this.next = sinon.stub()
+
+      this.domain = 'example.com'
+    }
   })
 
   afterEach(function () {
@@ -32,6 +52,8 @@ describe('mail_from.is_resolvable', function () {
 
   describe('hook_mail', function () {
     it('Allow - mail_from without host', async function () {
+      this.setup()
+
       await this.plugin.hook_mail(this.next, this.connection, [{}])
 
       assert.equal(this.txt.results.get(this.plugin).skip[0], 'null host')
@@ -41,6 +63,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - get_mx timeout', async function () {
+      this.setup()
+
       // Configure the stub to simulate a timeout
       const timeoutError = new Error('DNS request timed out')
       timeoutError.code = dnsPromises.TIMEOUT
@@ -63,7 +87,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - resolveMx timeout', async function () {
-      this.plugin.cfg.reject.no_mx = 'deny'
+      this.configfile.reject.no_mx = 'false'
+      this.setup()
 
       this.get_mx_spy.restore()
 
@@ -89,6 +114,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - No MX for your FROM address', async function () {
+      this.setup()
+
       this.get_mx_spy.resolves([])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -103,7 +130,9 @@ describe('mail_from.is_resolvable', function () {
 
     it('DENYSOFT - No MX for your FROM address', async function () {
       // Make sure old config works as intended.
-      this.plugin.cfg.reject.no_mx = 'false'
+      this.configfile.reject.no_mx = 'false'
+      this.setup()
+
       this.get_mx_spy.resolves([])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -122,7 +151,9 @@ describe('mail_from.is_resolvable', function () {
 
     it('DENY - No MX for your FROM address', async function () {
       // Make sure old config works as intended.
-      this.plugin.cfg.reject.no_mx = 'true'
+      this.configfile.reject.no_mx = 'true'
+      this.setup()
+
       this.get_mx_spy.resolves([])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -136,9 +167,10 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('Allow - MX is IP address', async function () {
-      this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
+      this.configfile.main.allow_mx_ip = true
+      this.setup()
 
-      this.plugin.cfg.main.allow_mx_ip = true
+      this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
 
       await this.plugin.hook_mail(this.next, this.connection, [
         new Address(`<test@${this.domain}>`),
@@ -151,7 +183,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - resolve4 and resolve6 both timeout', async function () {
-      this.plugin.cfg.reject.no_mx = 'deny'
+      this.configfile.reject.no_mx = 'deny'
+      this.setup()
 
       this.get_mx_spy.resolves([{ exchange: `mx.${this.domain}` }])
 
@@ -182,7 +215,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - DNS server failure', async function () {
-      this.plugin.cfg.reject.no_mx = 'deny'
+      this.configfile.reject.no_mx = 'deny'
+      this.setup()
 
       this.get_mx_spy.resolves([{ exchange: `mx.${this.domain}` }])
 
@@ -210,7 +244,9 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENYSOFT - No valid MX for the FROM address', async function () {
-      this.plugin.cfg.reject.no_mx = 'defer'
+      this.configfile.reject.no_mx = 'defer'
+      this.setup()
+
       this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -228,7 +264,9 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('Allow - No valid MX for the FROM address', async function () {
-      this.plugin.cfg.reject.no_mx = 'no'
+      this.configfile.reject.no_mx = 'no'
+      this.setup()
+
       this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -242,6 +280,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - No valid MX for the FROM address', async function () {
+      this.setup()
+
       this.get_mx_spy.resolves([{ exchange: '64.233.186.26' }])
 
       await this.plugin.hook_mail(this.next, this.connection, [
@@ -259,6 +299,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('Allow - valid MX hostname resolved to IPv6', async function () {
+      this.setup()
+
       this.resolve_mx_hosts_spy = sinon.stub(net_utils, 'resolve_mx_hosts')
 
       this.get_mx_spy.resolves([{ exchange: 'gmail-smtp-in.l.google.com' }])
@@ -277,6 +319,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('Allow - valid MX hostname resolved to IPv4', async function () {
+      this.setup()
+
       this.resolve_mx_hosts_spy = sinon.stub(net_utils, 'resolve_mx_hosts')
 
       this.get_mx_spy.resolves([{ exchange: 'gmail-smtp-in.l.google.com' }])
@@ -296,6 +340,8 @@ describe('mail_from.is_resolvable', function () {
     })
 
     it('DENY - MX hostname does not resolve', async function () {
+      this.setup()
+
       this.resolve_mx_hosts_spy = sinon.stub(net_utils, 'resolve_mx_hosts')
 
       this.get_mx_spy.resolves([{ exchange: 'mx.${this.domain}' }])


### PR DESCRIPTION
Closes #8

Changes proposed in this pull request:

- Add option to not deny transaction on missing or invalid MX record.

Fixes #8

Checklist:

- [x] docs updated
- [x] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
